### PR TITLE
feat: add watchosDeviceArm64 target

### DIFF
--- a/KtorKMPFileCaching/build.gradle.kts
+++ b/KtorKMPFileCaching/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
     macosArm64()
     watchosArm32()
     watchosArm64()
+    watchosDeviceArm64()
     watchosSimulatorArm64()
     watchosX64()
     tvosArm64()

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ The current supported targets are :
 | macosArm64            | ✅         |
 | watchosArm32          | ✅         |
 | watchosArm64          | ✅         |
+| watchosDeviceArm64    | ✅         |
 | watchosSimulatorArm64 | ✅         |
 | watchosX64            | ✅         |
+| tvosArm64             | ✅         |
 | tvosSimulatorArm64    | ✅         |
 | tvosX64               | ✅         |
-| mingwX64              | ✅         |
 | mingwX64              | ✅         |
 | linuxX64              | ✅         |
 | linuxArm64            | ✅         |


### PR DESCRIPTION
This pull request adds the 'watchosDeviceArm64' target to the library and updates the README to reflect the supported platforms.